### PR TITLE
Fix #148 allow text reader skip over container

### DIFF
--- a/Amazon.IonDotnet.Tests/Internals/TextReaderTest.cs
+++ b/Amazon.IonDotnet.Tests/Internals/TextReaderTest.cs
@@ -350,5 +350,32 @@ namespace Amazon.IonDotnet.Tests.Internals
             var reader = new UserTextReader(text);
             ReaderTestCommon.Blob_PartialRead(size, step, reader);
         }
+
+        [TestMethod()]
+        public void SkipOverListInStruct()
+        {
+            var reader = new UserTextReader("{ somelist: [ 1 ] }");
+            Assert.AreEqual(IonType.Struct, reader.MoveNext());
+            reader.StepIn();
+            Assert.AreEqual(IonType.List, reader.MoveNext());
+            Assert.AreEqual("somelist", reader.CurrentFieldName);
+            // Now skip over the list instead of stepping into it
+            Assert.AreEqual(IonType.None, reader.MoveNext());
+            reader.StepOut(); // Step out of struct
+            Assert.AreEqual(IonType.None, reader.MoveNext());
+        }
+
+        [TestMethod()]
+        public void SkipOverStructInList()
+        {
+            var reader = new UserTextReader("[{}]");
+            Assert.AreEqual(IonType.List, reader.MoveNext());
+            reader.StepIn();
+            Assert.AreEqual(IonType.Struct, reader.MoveNext());
+            // Skip over the struct instead of stepping in
+            Assert.AreEqual(IonType.None, reader.MoveNext());
+            reader.StepOut(); // Step out of list
+            Assert.AreEqual(IonType.None, reader.MoveNext());
+        }
     }
 }

--- a/Amazon.IonDotnet/Internals/Text/RawTextReader.cs
+++ b/Amazon.IonDotnet/Internals/Text/RawTextReader.cs
@@ -152,6 +152,8 @@ namespace Amazon.IonDotnet.Internals.Text
 
             this.state = GetStateAtContainerStart(this.valueType);
             this.containerStack.PushContainer(this.valueType);
+            var closeSymbol = this.GetClosingTokenForContainerType(this.valueType);
+            this.expectedContainerClosingSymbol.Push(closeSymbol);
             this.scanner.MarkTokenFinished();
 
             this.FinishValue();
@@ -605,17 +607,14 @@ namespace Amazon.IonDotnet.Internals.Text
                         break;
                     case ActionStartStruct:
                         this.valueType = IonType.Struct;
-                        this.expectedContainerClosingSymbol.Push(TextConstants.TokenCloseBrace);
                         this.state = StateBeforeFieldName;
                         return;
                     case ActionStartList:
                         this.valueType = IonType.List;
-                        this.expectedContainerClosingSymbol.Push(TextConstants.TokenCloseSquare);
                         this.state = StateBeforeAnnotationContained;
                         return;
                     case ActionStartSexp:
                         this.valueType = IonType.Sexp;
-                        this.expectedContainerClosingSymbol.Push(TextConstants.TokenCloseParen);
                         this.state = StateBeforeAnnotationSexp;
                         return;
                     case ActionStartLob:
@@ -754,6 +753,18 @@ namespace Amazon.IonDotnet.Internals.Text
                 case TextConstants.TokenCloseBrace: return '}';
                 case TextConstants.TokenCloseSquare: return ']';
                 default: return ' ';
+            }
+        }
+
+        private int GetClosingTokenForContainerType(IonType containerType)
+        {
+            switch (containerType)
+            {
+                case IonType.Struct: return TextConstants.TokenCloseBrace;
+                case IonType.List: return TextConstants.TokenCloseSquare;
+                case IonType.Sexp: return TextConstants.TokenCloseParen;
+                default:
+                    throw new Exception("Invalid value type while determining expectedContainerClosingSymbol");
             }
         }
 


### PR DESCRIPTION
As mentioned in the issue, avoid pushing the container closing token onto the `expectedContainerClosingSymbol` stack when `MoveNext` is called and instead only push it when `StepIn` is called.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
