### PR TITLE
Fix #151 - support Timestamp precision in text format

### DIFF
--- a/Amazon.IonDotnet.Tests/Internals/TextWriterJsonTest.cs
+++ b/Amazon.IonDotnet.Tests/Internals/TextWriterJsonTest.cs
@@ -151,6 +151,43 @@ namespace Amazon.IonDotnet.Tests.Internals
             Assert.AreEqual("{\"value\":\"2010-06-15T03:30:45.0000000-00:00\"}", this.sw.ToString());
         }
 
+        [DataTestMethod]
+        [DataRow(Timestamp.Precision.Year, "{\"value\":\"2010T\"}")]
+        [DataRow(Timestamp.Precision.Month, "{\"value\":\"2010-06T\"}")]
+        [DataRow(Timestamp.Precision.Day, "{\"value\":\"2010-06-15\"}")]
+        [DataRow(Timestamp.Precision.Minute, "{\"value\":\"2010-06-15T03:30-00:00\"}")]
+        public void TestTimestampPrecision(Timestamp.Precision p, string expected)
+        {
+            Timestamp ts = new Timestamp(2010, 6, 15, 3, 30, 45, p);
+            value.SetField("value", factory.NewTimestamp(ts));
+            var reader = IonReaderBuilder.Build(value);
+            jsonWriter.WriteValues(reader);
+            Assert.AreEqual(expected, this.sw.ToString());
+        }
+
+        [TestMethod]
+        public void TestMinutePrecisionTimestamp()
+        {
+            var p = Timestamp.Precision.Minute;
+            Timestamp ts = new Timestamp(2010, 6, 15, 3, 30, 45, 5 * 60, 0, p);
+            value.SetField("value", factory.NewTimestamp(ts));
+            var reader = IonReaderBuilder.Build(value);
+            jsonWriter.WriteValues(reader);
+            Assert.AreEqual("{\"value\":\"2010-06-15T03:30+05:00\"}", this.sw.ToString());
+        }
+
+        [TestMethod]
+        public void TestMinutePrecisionTimestampUtc()
+        {
+            var p = Timestamp.Precision.Minute;
+            Timestamp ts =
+                new Timestamp(2010, 6, 15, 3, 30, 45, 0, 0, p, DateTimeKind.Utc);
+            value.SetField("value", factory.NewTimestamp(ts));
+            var reader = IonReaderBuilder.Build(value);
+            jsonWriter.WriteValues(reader);
+            Assert.AreEqual("{\"value\":\"2010-06-15T03:30Z\"}", this.sw.ToString());
+        }
+
         [TestMethod]
         [ExpectedException(typeof(NotSupportedException))]
         public void TestClob()

--- a/Amazon.IonDotnet/Timestamp.cs
+++ b/Amazon.IonDotnet/Timestamp.cs
@@ -473,9 +473,44 @@ namespace Amazon.IonDotnet
 
         public override string ToString()
         {
-            return this.DateTimeValue.Kind == DateTimeKind.Unspecified
-                ? this.DateTimeValue.ToString("O") + "-00:00"
-                : this.AsDateTimeOffset().ToString("O", System.Globalization.CultureInfo.InvariantCulture);
+            var culture = System.Globalization.CultureInfo.InvariantCulture;
+            switch (this.TimestampPrecision)
+            {
+                case Precision.Year:
+                    return this.DateTimeValue.ToString("yyyyT", culture);
+                case Precision.Month:
+                    return this.DateTimeValue.ToString("yyyy-MMT", culture);
+                case Precision.Day:
+                    return this.DateTimeValue.ToString("yyyy-MM-dd", culture);
+                case Precision.Minute:
+                    switch (this.DateTimeValue.Kind)
+                    {
+                        case DateTimeKind.Utc:
+                            return this.DateTimeValue.ToString("yyyy-MM-ddTHH:mmK", culture);
+                        case DateTimeKind.Unspecified:
+                            return this.DateTimeValue.ToString("yyyy-MM-ddTHH:mm", culture) + "-00:00";
+                        case DateTimeKind.Local:
+                            return this.AsDateTimeOffset().ToString("yyyy-MM-ddTHH:mmK", culture);
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+
+                case Precision.Second:
+                    switch (this.DateTimeValue.Kind)
+                    {
+                        case DateTimeKind.Utc:
+                            return this.DateTimeValue.ToString("O", culture);
+                        case DateTimeKind.Unspecified:
+                            return this.DateTimeValue.ToString("O", culture) + "-00:00";
+                        case DateTimeKind.Local:
+                            return this.AsDateTimeOffset().ToString("yyyy-MM-ddTHH:mmK", culture);
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
         }
 
         public bool Equals(Timestamp other)


### PR DESCRIPTION
Support `Precision` values other than `Second` in the text format.

I also noticed that timestamps with `DateTimeKind.Utc` seemed to always have `+00:00` on the end instead of `Z` because `AsDateTimeOffset` doesn't know if a timestamp is supposed to be UTC.

This isn't really a backwards compatible change so not sure if this would require a major version bump or something...

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
