### PR TITLE
Update test project configuration so that tests can run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,12 @@ jobs:
         with:
           submodules: recursive
       - name: Setup .Net
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: ${{ matrix.dotnet }}
+          dotnet-version: |
+            ${{ matrix.dotnet }}
+            7.0.x
       - name: Project Build
         run: dotnet build --configuration Release
       - name: Project Test
-        run: dotnet test --configuration Release --no-build --no-restore --verbosity normal --framework ${{ matrix.dotnet }}
+        run: dotnet test --configuration Release --no-build --no-restore --verbosity normal --framework net7.0

--- a/Amazon.IonDotnet.Tests/Amazon.IonDotnet.Tests.csproj
+++ b/Amazon.IonDotnet.Tests/Amazon.IonDotnet.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <IsTestProject>true</IsTestProject>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <Configurations>Debug;Release;Perf</Configurations>


### PR DESCRIPTION
### Issue #, if available:

None.

### Description of changes:

Marks the test project as being a test project (`<IsTestProject>`), and updates the target framework _of the tests_ to a newer one that is runnable on ARM Macs.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
