### PR TITLE
Fix #155 don't use ion escaping in JSON mode

### DIFF
--- a/Amazon.IonDotnet.Tests/Internals/TextWriterJsonTest.cs
+++ b/Amazon.IonDotnet.Tests/Internals/TextWriterJsonTest.cs
@@ -189,6 +189,16 @@ namespace Amazon.IonDotnet.Tests.Internals
         }
 
         [TestMethod]
+        public void TestStringEscapingDoesntUseShortForm()
+        {
+            value.SetField("value", factory.NewString("--" + (char)0x1f + "--"));
+            var reader = IonReaderBuilder.Build(value);
+            jsonWriter.WriteValues(reader);
+            // Json doesn't support the shorter \xNN form, only \uNNNN
+            Assert.AreEqual("{\"value\":\"--\\u001f--\"}", this.sw.ToString());
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(NotSupportedException))]
         public void TestClob()
         {

--- a/Amazon.IonDotnet/Internals/Text/IonTextWriter.cs
+++ b/Amazon.IonDotnet/Internals/Text/IonTextWriter.cs
@@ -263,7 +263,12 @@ namespace Amazon.IonDotnet.Internals.Text
         public override void WriteString(string value)
         {
             this.StartValue();
-            if (value != null && !this.followingLongString && this.options.LongStringThreshold < value.Length)
+            if (this.options.JsonDowngrade)
+            {
+                this.textWriter.WriteJsonString(value);
+                this.CloseValue();
+            }
+            else if (value != null && !this.followingLongString && this.options.LongStringThreshold < value.Length)
             {
                 this.textWriter.WriteLongString(value);
                 this.CloseValue();


### PR DESCRIPTION
### Issue #155

### Description of changes:
Fix IonTextWriter to use `WriteJsonString` when in `JsonDowngrade` mode.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
