### PR TITLE
Fix infinite loop when reading truncated data

### DIFF
--- a/Amazon.IonDotnet.Tests/Internals/BinaryReaderTest.cs
+++ b/Amazon.IonDotnet.Tests/Internals/BinaryReaderTest.cs
@@ -335,6 +335,25 @@ namespace Amazon.IonDotnet.Tests.Internals
             }
         }
 
+        [TestMethod]
+        public void ReadAll_FailOnTruncatedData()
+        {
+            IIonReader binReader;
+            using (var ms = new MemoryStream()) {
+                ReadOnlySpan<byte> fullString = new ReadOnlySpan<byte>(new byte[] {
+                        0xE0, 0x01, 0x00, 0xEA, 0x85, 0x31, 0x32, 0x33, 0x34, 0x35
+                });
+                ms.Write(fullString.Slice(0, 9));
+
+                ms.Seek(0, SeekOrigin.Begin);
+                binReader = IonReaderBuilder.Build(ms);
+
+                var type = binReader.MoveNext();
+                Assert.AreEqual(IonType.String, type);
+                Assert.ThrowsException<UnexpectedEofException>(() => binReader.StringValue());
+            }
+        }
+
         /// <summary>
         /// Aims to test the correctness of skipping with step in-out in the middle
         /// of container

--- a/Amazon.IonDotnet/Internals/Binary/RawBinaryReader.cs
+++ b/Amazon.IonDotnet/Internals/Binary/RawBinaryReader.cs
@@ -1167,6 +1167,13 @@ namespace Amazon.IonDotnet.Internals.Binary
             while (length > 0)
             {
                 var amount = this.input.Read(bufferSpan.Slice(0, length));
+
+                // length > 0 (because we didn't stop)
+                if (amount == 0)
+                {
+                   throw new UnexpectedEofException();
+                }
+
                 length -= amount;
                 bufferSpan = bufferSpan.Slice(amount);
                 this.localRemaining -= amount;


### PR DESCRIPTION
Issue #, if available: n/a

### Description of changes:
This PR addresses an issue where an infinite loop could be triggered due to corrupted or truncated ion data.

Previous to this PR when retrieving bytes from the underlying input, RawBinaryReader did not check the return value of the call to Read. In the event that there was not enough bytes to return, Read would return 0 and the RawBinaryReader would get stuck in an infinite loop trying to read more data.

This PR adds the check of the return value and throws an `UnexpectedEofException` if the amount read is zero. A unit test to ensure this behavior was also added.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
