### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,11 +19,11 @@ jobs:
 
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             ${{ matrix.dotnet }}
@@ -44,7 +44,7 @@ jobs:
         dotnet: ['3.1']
 
     steps:
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-skip-session-tagging: true
           aws-region: us-west-2
@@ -55,12 +55,12 @@ jobs:
           role-duration-seconds: 900
 
       - name: Git Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             ${{ matrix.dotnet }}
@@ -71,15 +71,15 @@ jobs:
           dotnet build --configuration Release
 
           # Push unsigned DLL to S3
-          version_id=$( aws s3api put-object --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --body Amazon.IonDotnet/bin/Release/netstandard2.0/Amazon.IonDotnet.dll  --acl bucket-owner-full-control | jq '.VersionId' )
+          version_id=$( aws s3api put-object --bucket "${{ secrets.AWS_UNSIGNED_BUCKET }}" --key "${{ secrets.AWS_KEY }}" --body Amazon.IonDotnet/bin/Release/netstandard2.0/Amazon.IonDotnet.dll  --acl bucket-owner-full-control | jq '.VersionId' )
           job_id=""
           # Attempt to get Job ID from bucket tagging, will retry up to 3 times before exiting with a failure code.
           # Will sleep for 5 seconds between retries.
           for (( i=0; i<3; i++ ))
           do
             # Get job ID
-            id=$( aws s3api get-object-tagging --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --version-id ${version_id} | jq -r '.TagSet[0].Value' )
-            if [ $id != "null" ]
+            id=$( aws s3api get-object-tagging --bucket "${{ secrets.AWS_UNSIGNED_BUCKET }}" --key "${{ secrets.AWS_KEY }}" --version-id "${version_id}" | jq -r '.TagSet[0].Value' )
+            if [ "$id" != "null" ]
             then
               job_id=$id
               break
@@ -95,12 +95,12 @@ jobs:
           fi
 
           # Poll signed S3 bucket to see if the signed artifact is there
-          aws s3api wait object-exists --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }}-${job_id}
+          aws s3api wait object-exists --bucket "${{ secrets.AWS_SIGNED_BUCKET }}" --key "${{ secrets.AWS_KEY }}-${job_id}"
 
           # Get signed DLL from S3
-          aws s3api get-object --bucket ${{ secrets.AWS_SIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }}-${job_id} Amazon.IonDotnet/bin/Release/netstandard2.0/Amazon.IonDotnet.dll
+          aws s3api get-object --bucket "${{ secrets.AWS_SIGNED_BUCKET }}" --key "${{ secrets.AWS_KEY }}-${job_id}" Amazon.IonDotnet/bin/Release/netstandard2.0/Amazon.IonDotnet.dll
 
       - name: Publish to NuGet
         run: |
           dotnet pack --configuration Release --no-build
-          dotnet nuget push Amazon.IonDotnet/bin/Release/Amazon.IonDotnet.*.nupkg --api-key ${{ secrets.AWS_NUGET_KEY }} --source https://api.nuget.org/v3/index.json
+          dotnet nuget push Amazon.IonDotnet/bin/Release/Amazon.IonDotnet.*.nupkg --api-key "${{ secrets.AWS_NUGET_KEY }}" --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,13 +23,15 @@ jobs:
         with:
           submodules: recursive
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: ${{ matrix.dotnet }}
+          dotnet-version: |
+            ${{ matrix.dotnet }}
+            7.0.x
       - name: Build
         run: dotnet build --configuration Release
       - name: Unit test
-        run: dotnet test --configuration Release --no-build --no-restore --verbosity normal --framework ${{ matrix.dotnet }}
+        run: dotnet test --configuration Release --no-build --no-restore --verbosity normal --framework net7.0
 
   release:
     name: Release
@@ -58,9 +60,11 @@ jobs:
           submodules: recursive
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: ${{ matrix.dotnet }}
+          dotnet-version: |
+            ${{ matrix.dotnet }}
+            7.0.x
 
       - name: Sign
         run: |


### PR DESCRIPTION
### Issue #, if available: n/a

### Description of changes:
This PR addresses some [issues](https://github.com/amazon-ion/ion-dotnet/actions/runs/13164525991/job/36741295124) found in the release workflow while attempting to release v1.3.1.

The C# project is configured to use framework 7, which was not installed with the release workflow's setup-dotnet actions, so this PR adds 7.0 to the framework list to install in each matrix configuration, reflecting the changes to unit testing in #154.

This PR also updates the actions used in the release workflow, and addresses spellcheck issues found by actionlint, where variables were not quoted and could lead to unexpected behaviors.

It would be great to have the ability to run the release workflow prior to an actual release, so that we can ensure everything is working. I'm thinking we might be able to setup the release workflow to execute everything up to `Publish to NuGet` on any commit. Then only execute the publish with a new version release.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
