### PR TITLE
Update release workflow to get raw output from jq and add more debug info

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,8 +70,14 @@ jobs:
         run: |
           dotnet build --configuration Release
 
-          # Push unsigned DLL to S3
-          version_id=$( aws s3api put-object --bucket "${{ secrets.AWS_UNSIGNED_BUCKET }}" --key "${{ secrets.AWS_KEY }}" --body Amazon.IonDotnet/bin/Release/netstandard2.0/Amazon.IonDotnet.dll  --acl bucket-owner-full-control | jq '.VersionId' )
+          # Push unsigned DLL to S3 and capture full output
+          put_response=$(aws s3api put-object --bucket "${{ secrets.AWS_UNSIGNED_BUCKET }}" --key "${{ secrets.AWS_KEY }}" --body Amazon.IonDotnet/bin/Release/netstandard2.0/Amazon.IonDotnet.dll --acl bucket-owner-full-control)
+          echo "Put response: ${put_response}"
+
+          # Extract version ID with raw output
+          version_id=$(echo "$put_response" | jq -r '.VersionId')
+          echo "Version ID: ${version_id}
+
           job_id=""
           # Attempt to get Job ID from bucket tagging, will retry up to 3 times before exiting with a failure code.
           # Will sleep for 5 seconds between retries.


### PR DESCRIPTION
I was able to get past the permissions errors by adding more permissions to the role, but then I started getting:

```
An error occurred (InvalidArgument) when calling the GetObjectTagging operation: Invalid version id specified
```

See: https://github.com/amazon-ion/ion-dotnet/actions/runs/15743567873/job/44499862031

I verified that the artifact was successfully uploaded to the unsigned bucket and ended up being signed and added to the signed bucket.

This likely means the put was successful, but the parsing of the put response was incorrect. Using `jq -r` might help. If not, printing the entire put response and parsed version ID should help debug.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
